### PR TITLE
Fix link to Fronteers Slack in base template

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -29,7 +29,7 @@
 		</main>
 
 		<footer class="block">
-			<p>Een initiatief van het <a href="">Fronteers Accessibility Slack kanaal</a>.</p>
+			<p>Een initiatief van het <a href="https://fronteersnl.slack.com/">Fronteers Accessibility Slack kanaal</a>.</p>
 			<p>Nieuwe discussies kun je aandragen op de <a href="https://github.com/WCAG-Audit-Discussions/NL-BE">GitHub repository WCAG-Audit-Discussions/NL-BE</a></p>
 		</footer>
 	</body>


### PR DESCRIPTION
Fix missing link to Fronteers' Slack

Not sure if it's the right link, perhaps it should be https://fronteers-slack.herokuapp.com/